### PR TITLE
Add cosmosAddress Property in verificationMethod

### DIFF
--- a/index.html
+++ b/index.html
@@ -999,6 +999,43 @@ These properties are for use on a verification method object, in the value of
   }
         </pre>
       </section>
+
+      <section>
+        <h4>cosmosAddress</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://w3id.org/security">security-vocab</a>
+              </td>
+              <td>
+                <a href="https://w3id.org/security/v3-unstable">security-vocab-v3-unstable</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <pre class="example" title="Example of cosmosAddress property">
+  {
+    "@context":[
+      "https://www.w3.org/ns/did/v1",
+      "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#"
+    ],
+    "id":"did:example:t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0",
+    "publicKey":[{
+      "id": "did:example:t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0#vm-3",
+      "controller": "did:example:t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0",
+      "type": "EcdsaSecp256k1RecoveryMethod2020",
+      "cosmosAddress": "example1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0"
+    }]
+  }
+        </pre>
+      </section>
     </section>
 
     <section>


### PR DESCRIPTION
[Add cosmosAddress Property in verificationMethod like a ethereumAddress #342](https://github.com/w3c/did-spec-registries/issues/342)

Since Cosmos uses prefixes for addresses, it is an advantageous address system to use as did. So, after decomposing the address into prefix and remainder, we want to use it as a DID. And, like Ethereum, Cosmos would like to add the address of Cosmos to the property so that it can be verified by extracting the public key from the signature.

example1zp78zmtj4a7qvs4p2s08ngjn9rcwpaf5k9d0la (cosmos address)
did:example:zp78zmtj4a7qvs4p2s08ngjn9rcwpaf5k9d0la (did)